### PR TITLE
Changed tcp->xmit_size_goal_segs to tcp->gso_segs when kernel >= 3.19…

### DIFF
--- a/kernel/siw_cm.h
+++ b/kernel/siw_cm.h
@@ -152,12 +152,17 @@ extern void siw_cm_exit(void);
 static inline unsigned int get_tcp_mss(struct sock *sk)
 {
 	struct tcp_sock *tp = tcp_sk(sk);
-
+#if LINUX_VERSION_CODE < KERNEL_VERSION(3, 19, 0)
 	if (tp->xmit_size_goal_segs)
 		return tp->xmit_size_goal_segs * tp->mss_cache;
-
+#else
+	if (tp->gso_segs)
+		return tp->gso_segs * tp->mss_cache;
+#endif
 	else
 		return tp->mss_cache;
+
+        return 0;
 }
 
 #endif

--- a/kernel/siw_debug.c
+++ b/kernel/siw_debug.c
@@ -52,13 +52,19 @@
 #include "siw_cm.h"
 #include "siw_obj.h"
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(3, 19, 0)
+#define FDENTRY(f) (f->f_dentry)
+#else
+#define FDENTRY(f) (f->f_path.dentry)
+#endif
+
 
 static struct dentry *siw_debugfs;
 
 static ssize_t siw_show_qps(struct file *f, char __user *buf, size_t space,
 			    loff_t *ppos)
 {
-	struct siw_dev	*sdev = f->f_dentry->d_inode->i_private;
+	struct siw_dev	*sdev = FDENTRY(f)->d_inode->i_private;
 	struct list_head *pos, *tmp;
 	char *kbuf = NULL;
 	int len = 0, n, num_qp;
@@ -128,7 +134,7 @@ out:
 static ssize_t siw_show_ceps(struct file *f, char __user *buf, size_t space,
 			     loff_t *ppos)
 {
-	struct siw_dev	*sdev = f->f_dentry->d_inode->i_private;
+	struct siw_dev	*sdev = FDENTRY(f)->d_inode->i_private;
 	struct list_head *pos, *tmp;
 	char *kbuf = NULL;
 	int len = 0, n, num_cep;
@@ -198,7 +204,7 @@ out:
 static ssize_t siw_show_stats(struct file *f, char __user *buf, size_t space,
 			      loff_t *ppos)
 {
-	struct siw_dev	*sdev = f->f_dentry->d_inode->i_private;
+	struct siw_dev	*sdev = FDENTRY(f)->d_inode->i_private;
 	char *kbuf = NULL;
 	int len = 0;
 


### PR DESCRIPTION
Fixed compilation issues on kernel >= 3.19.0. struct tcp's xmit_size_goal_segs member changed to gso_segs and struct file's f_dentry member changed to f_path.dentry.

