### PR TITLE
Update siw_cm.h

### DIFF
--- a/kernel/siw_cm.h
+++ b/kernel/siw_cm.h
@@ -158,15 +158,7 @@ static inline unsigned int get_tcp_mss(struct sock *sk)
 {
 	struct tcp_sock *tp = tcp_sk(sk);
 
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 19, 0) || defined(IS_RH_7_2)
-	if (tp->gso_segs)
-		return tp->gso_segs * tp->mss_cache;
-#else
-	if (tp->xmit_size_goal_segs)
-		return tp->xmit_size_goal_segs * tp->mss_cache;
-#endif
-	else
-		return tp->mss_cache;
+	return tp->mss_cache;
 }
 
 #endif


### PR DESCRIPTION
This issue was observed during interoperability testing between softiwarp and iwarp device. The FPDU length received was larger than mss. This is because the tcp mss is always the tp->mss_cache, even if fragmentation is enabled, eventually the tcp packets on the wire are of size mss ( the device fragments them, or software gso does if device does not support fragmentation ). The specification specifies that the FPDU length needs to be less than mss.